### PR TITLE
Adding NACC to AQM Regional Workflow

### DIFF
--- a/conf/aqm.externals.cfg
+++ b/conf/aqm.externals.cfg
@@ -37,5 +37,12 @@ hash = 0abeecf9
 local_path = sorc/EMC_post
 required = True
 
+[arl_nacc]
+protocol=git
+repo_url = https://github.com/noaa-oar-arl/NACC
+branch = master
+local_path = sorc/arl_nacc
+required = True
+
 [externals_description]
 schema_version = 1.0.0

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -9,6 +9,17 @@ set -eux
 
 export USE_PREINST_LIBS="true"
 
+# Check for input argument: this should be the "platform" if it exists.
+#
+if [ $# -eq 0 ]; then
+  echo
+  echo "No 'platform' argument supplied"
+  echo "Using directory structure to determine machine settings"
+  platform=''
+else
+  platform=$1
+fi
+
 #------------------------------------
 # END USER DEFINED STUFF
 #------------------------------------
@@ -49,6 +60,17 @@ then
     $Build_nexus && {
 echo " .... Building nexus .... "
 ./build_nexus.sh > $logs_dir/build_nexus.log 2>&1
+}
+fi
+
+#------------------------------------
+# Check and build nacc
+#------------------------------------
+if [ -d "./arl_nacc" ]
+then
+    $Build_nacc && {
+echo " .... Building nacc .... "
+./build_nacc.sh $platform > $logs_dir/build_nacc.log 2>&1
 }
 fi
 

--- a/sorc/build_nacc.sh
+++ b/sorc/build_nacc.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+set -eux
+#
+# Check for input argument: this should be the "platform" if it exists.
+#
+if [ $# -eq 0 ]; then
+  echo
+  echo "No 'platform' argument supplied"
+  echo "Using directory structure to determine machine settings"
+  platform=''
+else 
+  platform=$1
+fi
+#
+source ./machine-setup.sh $platform > /dev/null 2>&1
+if [ $platform = "wcoss_cray" ]; then
+  platform="cray"
+fi
+
+#
+# Set the name of the package.  This will also be the name of the execu-
+# table that will be built.
+#
+package_name="arl_nacc"
+#
+# Make an exec folder if it doesn't already exist.
+#
+mkdir -p ../exec
+#
+# Change directory to where the source code is located.
+# 
+cd ${package_name}/parallel/src
+home_dir=`pwd`/../../../..
+srcDir=`pwd`
+#
+# Load modules.
+#
+set +x
+source ../../../../modulefiles/codes/${platform}/global_equiv_resol
+module load impi
+module list
+#module load cmake
+#source config/modulefiles.${platform}
+#
+MPICH_UNEX_BUFFER_SIZE=256m
+MPICH_MAX_SHORT_MSG_SIZE=64000
+MPICH_PTL_UNEX_EVENTS=160k
+KMP_STACKSIZE=2g
+F_UFMTENDIAN=big
+#
+# HDF5, NetCDF, IOAPI, and MPI (for parallel NACC) directories.
+#
+if [ $platform = "cray" ]; then
+  cp Makefile_cray Makefile
+  HDF5=${HDF5}
+  NETCDF=${NETCDF}
+  IOAPI=/gpfs/hps3/emc/naqfc/noscrub/Youhua.Tang/CMAQ/ioapi-3.2/Linux2_x86_64ifort
+  MPI=/opt/cray/mpt/7.2.0/gni/mpich2-intel/140
+elif [ $platform = "theia" ]; then
+ echo "Uncertain libraries for theia..untested"
+ echo "Error during '$target' build"
+ exit 1
+elif [ $platform = "hera" ]; then
+  cp Makefile_intel Makefile
+  HDF5=${HDF5}
+  NETCDF=${NETCDF}
+  IOAPI=/scratch2/NCEPDEV/naqfc/Youhua.Tang/CMAQ/ioapi-3.2/Linux2_x86_64ifort
+  MPI=/apps/intel/compilers_and_libraries_2018/linux/mpi/intel64
+elif [ $platform = "cheyenne" ]; then
+  echo "Uncertain libraries for cheyenne..untested"
+  echo "Error during '$target' build"
+  exit 1
+elif [ $platform = "jet" ]; then
+  echo "Uncertain libraries for jet..untested"
+  echo "Error during '$target' build"
+  exit 1
+fi
+
+#build the file
+
+export COMPILER=${COMPILER:-intel}
+#export CMAKE_Platform=linux.${COMPILER}
+#export CMAKE_C_COMPILER=${CMAKE_C_COMPILER:-mpicc}
+#export CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER:-mpicxx}
+#export CMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER:-mpif90}
+
+#cmake CMakeLists.txt
+make clean
+#make -j ${BUILD_JOBS:-4} FC=mpiifort IOAPI=${IOAPI} NETCDF=${NETCDF}
+make -j FC=mpiifort IOAPI=${IOAPI} NETCDF=${NETCDF} MPI=${MPI}
+
+exit

--- a/sorc/partial_build.sh
+++ b/sorc/partial_build.sh
@@ -1,7 +1,7 @@
 #
 # define the array of the name of build program
 #
- declare -a Build_prg=("Build_libs" "Build_nexus" "Build_forecast" "Build_gsi" \
+ declare -a Build_prg=("Build_libs" "Build_nexus" "Build_nacc" "Build_forecast" "Build_gsi" \
                        "Build_post" "Build_utils" "Build_chgres" "Build_chgres_cube" \
                        "Build_orog" "Build_sfc_climo_gen" "Build_regional_grid" "Build_nctools" \
                        "Build_mosaic_file" "Build_global_equiv_resol")

--- a/sorc/regional_build.cfg
+++ b/sorc/regional_build.cfg
@@ -7,6 +7,7 @@
  Building post (post) .................................. yes
  Building utils (utils) ................................ yes
  Building nexus (nexus) ................................ yes
+ Building nacc (nacc) .................................. yes
  Building chgres (chgres) .............................. no
  Building chgres_cube (chgres_cube) .................... yes
  Building sfc_climo_gen (sfc_climo_gen) ................ yes


### PR DESCRIPTION
I have added our new NOAA-ARL Atmosphere-Chemistry Coupler Version 1.0.0 (NACCv1.0.0) to the AQM regional workflow as an additional option that can be used to process the global FV3-GFSv16 output to drive the latest offline CMAQv5.3.1 for any defined regional domain/configuration.  NACC and its documentation may be found in the following repo:  https://github.com/noaa-oar-arl/NACC.git  NACC is the basis for the next major upgrade for NAQFC (i.e., NACC-CMAQv5.3.1).  
 